### PR TITLE
Improve node customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,17 +125,17 @@
         </div>
         <div class="form-group">
             <label>Dimensione Nodo:</label>
-            <input type="range" id="node-size" min="60" max="300" value="90" step="10">
+            <input type="range" id="node-size" min="40" max="500" value="90" step="10">
             <span id="node-size-value">90px</span>
         </div>
         <div class="form-group">
             <label>Dimensione Testo:</label>
-            <input type="range" id="node-text-size" min="10" max="24" value="16" step="1">
+            <input type="range" id="node-text-size" min="8" max="48" value="16" step="1">
             <span id="node-text-size-value">16px</span>
         </div>
         <div class="form-group">
              <label>Dimensione Icona:</label>
-             <input type="range" id="node-icon-size" min="14" max="54" value="26" step="2">
+             <input type="range" id="node-icon-size" min="12" max="80" value="26" step="2">
              <span id="node-icon-size-value">26px</span>
         </div>
         <div class="form-group">

--- a/main.js
+++ b/main.js
@@ -382,16 +382,17 @@ function disegnaNodo(nodo) {
                 .attr("stroke-width", strokeWidth);
 
     // ICONA
+    const shapeOffset = nodo.shape === 'circle' || nodo.shape === 'hex' ? 5 : 0;
     g.append("foreignObject")
         .attr("x", -nodo.iconSize / 2)
-        .attr("y", -nodo.size / 2.2 + (nodo.shape === 'circle' || nodo.shape === 'hex' ? 5 : 0) ) // Adjust Y for icon based on shape
+        .attr("y", -nodo.iconSize / 2 - shapeOffset)
         .attr("width", nodo.iconSize)
-        .attr("height", nodo.iconSize + 8) // Extra space for potential descenders
+        .attr("height", nodo.iconSize)
         .style("pointer-events", "none")
         .html(getIconSVG(nodo.icon, nodo.iconSize, nodo.textColor));
     
     // TESTO con wrapping automatico
-    const textYOffset = nodo.iconSize / 1.5 + (nodo.shape === 'circle' || nodo.shape === 'hex' ? 5 : 0); // Adjust Y for text
+    const textYOffset = nodo.iconSize / 2 + 4 + shapeOffset; // Keep text close to icon
     const textElement = g.append("text")
         .attr("class", "node-text")
         .attr("font-size", nodo.textSize)


### PR DESCRIPTION
## Summary
- expand allowed range for node, text and icon size
- keep icon and text closer within nodes for better alignment

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851424027dc8326a40da79bbd0af8fd