### PR TITLE
Scale node text spacing with icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This single page application runs entirely in the browser and lets you create no
 - Import/export JSON
 - Export map as PNG or PDF
 - Save to local storage
+- Icon/text spacing now scales with icon size to avoid overlap
 
 ## Keyboard Shortcuts
 

--- a/main.js
+++ b/main.js
@@ -370,7 +370,8 @@ function disegnaNodo(nodo) {
 
     // Dynamically space icon and text based on current sizes
     const totalTextHeight = lines.length * lineHeight;
-    const gap = Math.max(4, nodo.size * 0.05);
+    // use icon size so large icons get more space
+    const gap = Math.max(8, nodo.iconSize * 0.2);
     const totalHeight = nodo.iconSize + totalTextHeight + gap;
     const offset = (nodo.size - totalHeight) / 2;
 


### PR DESCRIPTION
## Summary
- update gap calculation so larger icons get more space
- document new spacing rule

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855a0b2fadc832682528f9c1a153d6c