### PR TITLE
Add adjustable connection label size

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,11 @@
                 <option value="dotted">Linea punteggiata</option>
             </select>
         </div>
+        <div class="form-group">
+            <label>Dimensione testo:</label>
+            <input type="range" id="connection-label-size" min="8" max="36" value="12">
+            <span id="connection-label-size-value">12px</span>
+        </div>
     </div>
 </div>
 

--- a/main.js
+++ b/main.js
@@ -492,6 +492,7 @@ function creaConnessione(sourceNode, targetNode, label = "") {
         source: sourceNode,
         target: targetNode,
         label,
+        labelSize: 12,
         color: CONFIG.colors.connections[Math.floor(Math.random() * CONFIG.colors.connections.length)],
         arrow: "forward",
         style: "solid" // solid, dashed, dotted
@@ -585,6 +586,7 @@ function disegnaConnessione(conn) {
             .attr("x", mx)
             .attr("y", my - 7)
             .attr("text-anchor", "middle")
+            .style("font-size", (conn.labelSize || 12) + "px")
             .text(conn.label);
     }
     if (appState.selectedConnection && appState.selectedConnection.id === conn.id) {
@@ -927,6 +929,8 @@ function aggiornaEditorConn() {
     document.getElementById("connection-label").value = c.label || "";
     document.getElementById("connection-arrow").value = c.arrow || "forward";
     document.getElementById("connection-style").value = c.style || "solid";
+    document.getElementById("connection-label-size").value = c.labelSize || 12;
+    document.getElementById("connection-label-size-value").textContent = (c.labelSize || 12) + "px";
     popolaColorPicker("connection-colors", CONFIG.colors.connections, c.color, (col) => { c.color = col; aggiornaConnessioni(); saveToHistory(); });
 }
 
@@ -967,6 +971,7 @@ document.getElementById("node-shape").onchange = e => { if(appState.selectedNode
 
 // Connection editor inputs
 handleSidebarInput("connection-label", "label", false, false, aggiornaConnessioni);
+handleSidebarInput("connection-label-size", "labelSize", true, false, aggiornaConnessioni);
 document.getElementById("connection-arrow").onchange = e => { if(appState.selectedConnection) { appState.selectedConnection.arrow = e.target.value; aggiornaConnessioni(); saveToHistory(); }};
 document.getElementById("connection-style").onchange = e => { if(appState.selectedConnection) { appState.selectedConnection.style = e.target.value; aggiornaConnessioni(); saveToHistory(); }};
 
@@ -1224,6 +1229,7 @@ function caricaMappa(data) {
             if (sourceNode && targetNode) {
                 const newConn = { ...connData, source: sourceNode, target: targetNode };
                 newConn.style = newConn.style || "solid";
+                newConn.labelSize = newConn.labelSize || 12;
                 appState.connections.push(newConn);
             } else {
                 console.warn("Impossibile trovare nodi per la connessione:", connData);

--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background:
 .node-icon { pointer-events:none; }
 .connection { stroke:#34495e; stroke-width:2.5; transition: stroke 0.2s, stroke-width 0.2s; }
 .connection.selected { stroke:#3498db; stroke-width:3.5; }
-.connection-label { font-size:12px; fill:#2c3e50; font-weight:500; user-select:none; pointer-events:none; }
+.connection-label { fill:#2c3e50; font-weight:500; user-select:none; pointer-events:none; }
 .sidebar { position:fixed;right:-380px;top:75px;width:380px;height:calc(100vh - 75px);background:rgba(255,255,255,0.98);backdrop-filter:blur(15px);box-shadow:-4px 0 20px rgba(0,0,0,0.15);transition:right .35s;z-index:200;padding:20px;overflow-y:auto;border-radius:12px 0 0 0;}
 .sidebar.open {right:0;}
 .form-group{margin-bottom:18px;}


### PR DESCRIPTION
## Summary
- allow connections to store a `labelSize`
- draw connection labels based on that value
- let the connection editor change label size
- default and import/export updated for new property
- remove fixed font-size from `.connection-label` style

## Testing
- `node` - no tests present

------
https://chatgpt.com/codex/tasks/task_e_6855cf4804f48326b79cd88716273d26