### PR TITLE
Improve connection hit area

### DIFF
--- a/main.js
+++ b/main.js
@@ -563,6 +563,12 @@ function disegnaConnessione(conn) {
     if (conn.arrow === "backward") markerStart = "url(#arrowhead-reverse)";
     if (conn.arrow === "both") { markerEnd = "url(#arrowhead)"; markerStart = "url(#arrowhead-reverse)"; }
 
+    // Invisible thicker line for easier hit detection
+    g.append("line")
+        .attr("class", "connection-hit")
+        .attr("x1", p1x).attr("y1", p1y)
+        .attr("x2", p2x).attr("y2", p2y);
+
     const line = g.append("line")
         .attr("class", "connection")
         .attr("x1", p1x).attr("y1", p1y)

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,7 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background:
 .node-icon { pointer-events:none; }
 .connection { stroke:#34495e; stroke-width:2.5; transition: stroke 0.2s, stroke-width 0.2s; }
 .connection.selected { stroke:#3498db; stroke-width:3.5; }
+.connection-hit { stroke: transparent; stroke-width:10; pointer-events: stroke; }
 .connection-label { font-size:12px; fill:#2c3e50; font-weight:500; user-select:none; pointer-events:none; }
 .sidebar { position:fixed;right:-380px;top:75px;width:380px;height:calc(100vh - 75px);background:rgba(255,255,255,0.98);backdrop-filter:blur(15px);box-shadow:-4px 0 20px rgba(0,0,0,0.15);transition:right .35s;z-index:200;padding:20px;overflow-y:auto;border-radius:12px 0 0 0;}
 .sidebar.open {right:0;}


### PR DESCRIPTION
## Summary
- add invisible connection-hit line to make selecting connections easier
- style `.connection-hit` with transparent stroke

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855cf3665b48326aceab7de2dad6e4a