### PR TITLE
Add euro.html — full-bleed iframe to embed Imparo l'Euro app

### DIFF
--- a/euro.html
+++ b/euro.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Imparo l'Euro - App Inclusiva</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    iframe {
+      width: 100%;
+      height: 100%;
+      border: 0;
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <iframe
+    src="https://service-22-imparo-l-euro-552441125436.us-west1.run.app/"
+    title="Imparo l'Euro - App Inclusiva"
+    loading="lazy"
+    referrerpolicy="no-referrer"
+  ></iframe>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple static wrapper page that embeds the Imparo l'Euro app so it can be opened directly from the repo (convenient preview / integration point).

### Description
- Add `euro.html`, a minimal fullscreen page that loads the remote app in a full-bleed `<iframe>` with `loading="lazy"` and `referrerpolicy="no-referrer"`.

### Testing
- Started a local HTTP server and used Playwright to navigate to `http://127.0.0.1:8000/euro.html` and successfully captured a screenshot, confirming the page loads and the iframe is rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4091fe608326ba6deda34460cd83)